### PR TITLE
remove scope from todo model and update todos:remove task

### DIFF
--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -16,7 +16,6 @@ class Todo < ApplicationRecord
 
   scope :completed, -> { where completed: true }
   scope :active, -> { where completed: false }
-  scope :older_than_two_weeks, -> { where "created_at <= ?", 2.weeks.ago.to_datetime }
 
   def active?
     !completed?

--- a/lib/tasks/todos.rake
+++ b/lib/tasks/todos.rake
@@ -1,6 +1,6 @@
 namespace :todos do
   desc "Remove task with more than 2 weeks"
   task remove: :environment do
-    Todo.older_than_two_weeks.destroy_all
+    Todo.where("created_at <= ?", 2.weeks.ago).destroy_all
   end
 end


### PR DESCRIPTION
We don't need the model scope for anything so this removes the scope from the model and updates the todos:remove task to add in the query that was accomplished by using the scope. 