### PR TITLE
add standardize binstub and add instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ _Especially when you consider the deveopment, deployment, operating, and mainten
 
 If you find this approach lacking, consider giving [StimulusReflex](https://github.com/hopsoft/stimulus_reflex)
 a try before reaching for a complex JavaScript framework.
+
+## Contributing
+
+This project uses [Standard](https://github.com/testdouble/standard)
+and [Prettier](https://github.com/prettier/prettier) to minimize bike shedding related to code formatting.
+
+Please run `./bin/standardize` prior submitting pull requests.

--- a/bin/standardize
+++ b/bin/standardize
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "======== running standardrb ========"
+bundle exec standardrb --fix
+echo "======== running prettier ========"
+yarn prettier-fix


### PR DESCRIPTION
Add standardize binstub to run standardrb and prettier. Relies on #4, which adds both those linters. Add instructions to the readme.